### PR TITLE
Added support for IDN #31

### DIFF
--- a/Altairis.AutoAcme.Core/AcmeEnvironment.cs
+++ b/Altairis.AutoAcme.Core/AcmeEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 
@@ -10,6 +11,7 @@ namespace Altairis.AutoAcme.Core {
         private const int ERRORLEVEL_SUCCESS = 0;
         private const int ERRORLEVEL_FAILURE = 1;
         public const string DEFAULT_CONFIG_NAME = "autoacme.json";
+        public static readonly IdnMapping IDN_MAPPING = new IdnMapping();
         public static bool VerboseMode;
         public static Store CfgStore;
 
@@ -112,6 +114,18 @@ namespace Altairis.AutoAcme.Core {
             }
 
             Environment.Exit(ERRORLEVEL_FAILURE);
+        }
+
+        public static string ToAsciiHostName(this string hostName) {
+            return IDN_MAPPING.GetAscii(hostName.Trim().ToLowerInvariant().Normalize());
+        }
+
+        public static string ExplainHostName(this string hostName) {
+            var unicodeHostname = IDN_MAPPING.GetUnicode(hostName);
+            if (!hostName.Equals(unicodeHostname, StringComparison.OrdinalIgnoreCase)) {
+                return $"{unicodeHostname} ({hostName})";
+            }
+            return unicodeHostname;
         }
     }
 }

--- a/Altairis.AutoAcme.Manager/Program.cs
+++ b/Altairis.AutoAcme.Manager/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,7 @@ namespace Altairis.AutoAcme.Manager {
     internal class Program {
         private static readonly Uri DEFAULT_SERVER_URL = new Uri("https://acme-v01.api.letsencrypt.org/directory");
         private static readonly Uri STAGING_SERVER_URL = new Uri("https://acme-staging.api.letsencrypt.org/directory");
+        private static readonly IdnMapping IDN_MAPPING = new IdnMapping();
 
         private static void Main(string[] args) {
             Trace.Listeners.Add(new ConsoleTraceListener());
@@ -149,7 +151,7 @@ namespace Altairis.AutoAcme.Manager {
             AcmeEnvironment.VerboseMode = verbose;
             if (AcmeEnvironment.CfgStore == null)
                 AcmeEnvironment.LoadConfig(cfgFileName);
-            hostName = hostName.Trim().ToLower();
+            hostName = hostName.ToAsciiHostName();
 
             var result = AcmeContext.TestAuthorization(hostName, AcmeEnvironment.CreateChallenge, AcmeEnvironment.CleanupChallenge);
             Trace.WriteLine(string.Empty);
@@ -171,16 +173,16 @@ namespace Altairis.AutoAcme.Manager {
             AcmeEnvironment.VerboseMode = verbose;
             if (AcmeEnvironment.CfgStore == null)
                 AcmeEnvironment.LoadConfig(cfgFileName);
-            hostName = hostName.Trim().ToLower();
+            hostName = hostName.ToAsciiHostName();
 
             // Check if there already is host with this name
             Trace.Write("Checking host...");
             if (AcmeEnvironment.CfgStore.Hosts.Any(x => x.CommonName.Equals(hostName)))
-                AcmeEnvironment.CrashExit($"Host '{hostName}' is already managed.");
+                AcmeEnvironment.CrashExit($"Host '{hostName.ExplainHostName()}' is already managed.");
             Trace.WriteLine("OK");
 
             // Request certificate
-            Trace.WriteLine($"Requesting cerificate for {hostName}:");
+            Trace.WriteLine($"Requesting cerificate for {hostName.ExplainHostName()}:");
             Trace.Indent();
             CertificateRequestResult result = null;
             try {
@@ -266,13 +268,13 @@ namespace Altairis.AutoAcme.Manager {
             AcmeEnvironment.VerboseMode = verbose;
             if (AcmeEnvironment.CfgStore == null)
                 AcmeEnvironment.LoadConfig(cfgFileName);
-            hostName = hostName.Trim().ToLower();
+            hostName = hostName.ToAsciiHostName();
 
             // Check if there is host with this name
-            Trace.Write($"Finding host {hostName}...");
+            Trace.Write($"Finding host {hostName.ExplainHostName()}...");
             var host = AcmeEnvironment.CfgStore.Hosts.SingleOrDefault(x => x.CommonName.Equals(hostName));
             if (host == null)
-                AcmeEnvironment.CrashExit($"Host '{hostName}' was not found.");
+                AcmeEnvironment.CrashExit($"Host '{hostName.ExplainHostName()}' was not found.");
             Trace.WriteLine("OK");
 
             // Delete files

--- a/Altairis.AutoAcme.Manager/Program.cs
+++ b/Altairis.AutoAcme.Manager/Program.cs
@@ -7,12 +7,13 @@ using System.Linq;
 using System.Text;
 using Altairis.AutoAcme.Configuration;
 using Altairis.AutoAcme.Core;
+
+using Certes.Acme;
+
 using NConsoler;
 
 namespace Altairis.AutoAcme.Manager {
     internal class Program {
-        private static readonly Uri DEFAULT_SERVER_URL = new Uri("https://acme-v01.api.letsencrypt.org/directory");
-        private static readonly Uri STAGING_SERVER_URL = new Uri("https://acme-staging.api.letsencrypt.org/directory");
         private static readonly IdnMapping IDN_MAPPING = new IdnMapping();
 
         private static void Main(string[] args) {
@@ -112,9 +113,9 @@ namespace Altairis.AutoAcme.Manager {
                 Console.Write("> ");
                 var acmeServer = Console.ReadLine();
                 if (string.IsNullOrWhiteSpace(acmeServer)) {
-                    AcmeEnvironment.CfgStore.ServerUri = DEFAULT_SERVER_URL;
+                    AcmeEnvironment.CfgStore.ServerUri = WellKnownServers.LetsEncrypt;
                 } else if (acmeServer.Trim().Equals("staging", StringComparison.OrdinalIgnoreCase)) {
-                    AcmeEnvironment.CfgStore.ServerUri = STAGING_SERVER_URL;
+                    AcmeEnvironment.CfgStore.ServerUri = WellKnownServers.LetsEncryptStaging;
                 } else {
                     AcmeEnvironment.CfgStore.ServerUri = new Uri(acmeServer);
                 }


### PR DESCRIPTION
Hostnames can now contain Unicode characters which are correctly converted to IDN notation before processing, and hostnames which are IDN are explained as follows: `unicode.name (ascii.name)`