### PR TITLE
Fallback DNS => HTTP (self-hosted) when DNS test fails

### DIFF
--- a/Altairis.AutoAcme.Configuration/Store.cs
+++ b/Altairis.AutoAcme.Configuration/Store.cs
@@ -35,9 +35,9 @@ namespace Altairis.AutoAcme.Configuration {
 
         public Uri ServerUri { get; set; } = WellKnownServers.LetsEncryptV2;
 
-        public int ChallengeVerificationRetryCount { get; set; } = 10;
+        public int ChallengeVerificationRetryCount { get; set; } = 20;
 
-        public int ChallengeVerificationWaitSeconds { get; set; } = 5;
+        public int ChallengeVerificationWaitSeconds { get; set; } = 6;
 
         public int RenewDaysBeforeExpiration { get; set; } = 30;
 

--- a/Altairis.AutoAcme.Configuration/app.config
+++ b/Altairis.AutoAcme.Configuration/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Altairis.AutoAcme.Core/AcmeEnvironment.cs
+++ b/Altairis.AutoAcme.Core/AcmeEnvironment.cs
@@ -22,8 +22,13 @@ namespace Altairis.AutoAcme.Core {
         public static bool VerboseMode;
         public static Store CfgStore;
 
-        public static ChallengeResponseProvider CreateChallengeManager() {
+        public static IChallengeResponseProvider CreateChallengeManager() {
             try {
+                if (CfgStore.DnsChallenge && CfgStore.SelfHostChallenge) {
+                    return new FallbackChallengeResponseProvider(
+                                    new DnsChallengeResponseProvider(VerboseMode, CfgStore.DnsServer, CfgStore.DnsDomain),
+                                    new HttpChallengeHostedResponseProvider(VerboseMode, CfgStore.SelfHostUrlPrefix));
+                }
                 if (CfgStore.DnsChallenge) {
                     return new DnsChallengeResponseProvider(VerboseMode, CfgStore.DnsServer, CfgStore.DnsDomain);
                 }

--- a/Altairis.AutoAcme.Core/Altairis.AutoAcme.Core.csproj
+++ b/Altairis.AutoAcme.Core/Altairis.AutoAcme.Core.csproj
@@ -60,6 +60,7 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
@@ -71,6 +72,7 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
@@ -101,6 +103,7 @@
     <Compile Include="Challenges\HttpChallengeHostedResponseProvider.cs" />
     <Compile Include="Challenges\HttpChallengeResponseProvider.cs" />
     <Compile Include="Challenges\IChallengeResponseProvider.cs" />
+    <Compile Include="Log.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Altairis.AutoAcme.Core/Altairis.AutoAcme.Core.csproj
+++ b/Altairis.AutoAcme.Core/Altairis.AutoAcme.Core.csproj
@@ -96,9 +96,11 @@
     <Compile Include="CertificateRequestResult.cs" />
     <Compile Include="Challenges\ChallengeResponseProvider.cs" />
     <Compile Include="Challenges\DnsChallengeResponseProvider.cs" />
+    <Compile Include="Challenges\FallbackChallengeResponseProvider.cs" />
     <Compile Include="Challenges\HttpChallengeFileResponseProvider.cs" />
     <Compile Include="Challenges\HttpChallengeHostedResponseProvider.cs" />
     <Compile Include="Challenges\HttpChallengeResponseProvider.cs" />
+    <Compile Include="Challenges\IChallengeResponseProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Altairis.AutoAcme.Core/AutoAcmeContext.cs
+++ b/Altairis.AutoAcme.Core/AutoAcmeContext.cs
@@ -51,11 +51,11 @@ namespace Altairis.AutoAcme.Core {
             }
         }
 
-        public CertificateRequestResult GetCertificate(IEnumerable<string> hostNames, string pfxPassword, ChallengeResponseProvider challengeManager, bool skipTest = false) {
+        public CertificateRequestResult GetCertificate(IEnumerable<string> hostNames, string pfxPassword, IChallengeResponseProvider challengeManager, bool skipTest = false) {
             return GetCertificateAsync(hostNames, pfxPassword, challengeManager, skipTest).Result;
         }
 
-        public async Task<CertificateRequestResult> GetCertificateAsync(IEnumerable<string> hostNames, string pfxPassword, ChallengeResponseProvider challengeManager, bool skipTest = false) {
+        public async Task<CertificateRequestResult> GetCertificateAsync(IEnumerable<string> hostNames, string pfxPassword, IChallengeResponseProvider challengeManager, bool skipTest = false) {
             if (challengeManager == null) throw new ArgumentNullException(nameof(challengeManager));
             if (client == null) throw new ObjectDisposedException(nameof(AutoAcmeContext));
             if (context == null) throw new InvalidOperationException("Not logged in");

--- a/Altairis.AutoAcme.Core/AutoAcmeContext.cs
+++ b/Altairis.AutoAcme.Core/AutoAcmeContext.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
+using Altairis.AutoAcme.Configuration;
 using Altairis.AutoAcme.Core.Challenges;
 
 using Certes;
@@ -26,9 +26,7 @@ namespace Altairis.AutoAcme.Core {
             } else if (serverAddress == WellKnownServers.LetsEncryptStaging) {
                 serverAddress = WellKnownServers.LetsEncryptStagingV2;
             }
-            if (AcmeEnvironment.VerboseMode) {
-                Trace.WriteLine($"Using server {serverAddress}");
-            }
+            Log.WriteVerboseLine($"Using server {serverAddress}");
             this.serverAddress = serverAddress;
             client = new AcmeHttpClient(serverAddress);
         }
@@ -62,41 +60,44 @@ namespace Altairis.AutoAcme.Core {
 
             // Test authorization
             if (!skipTest) {
-                Trace.WriteLine("Testing authorization:");
-                Trace.Indent();
-                var probeResult = await challengeManager.TestAsync(hostNames).ConfigureAwait(false);
-                Trace.Unindent();
+                Log.WriteLine("Testing authorization:");
+                Log.Indent();
+                var probeResult = await challengeManager.TestAsync(hostNames).ConfigureAwait(true);
+                Log.Unindent();
                 if (!probeResult) throw new Exception("Test authorization failed");
             }
 
             // Prepare order
-            Trace.WriteLine("Preparing order");
-            var orderContext = await context.NewOrder(hostNames.ToArray()).ConfigureAwait(false);
+            Log.WriteLine("Preparing order");
+            Log.Indent();
+            var orderContext = await context.NewOrder(hostNames.ToArray()).ConfigureAwait(true);
             var certKey = KeyFactory.NewKey(AcmeEnvironment.CfgStore.KeyAlgorithm);
-            Trace.Unindent();
+            Log.Unindent();
 
             // Get authorization
-            Trace.WriteLine("Getting authorization:");
-            Trace.Indent();
-            var authorizations = await orderContext.Authorizations().ConfigureAwait(false);
-            var authorizationResult = await challengeManager.ValidateAsync(this, authorizations).ConfigureAwait(false);
-            Trace.Unindent();
+            Log.WriteLine("Getting authorization:");
+            Log.Indent();
+            var authorizations = await orderContext.Authorizations().ConfigureAwait(true);
+            var authorizationResult = await challengeManager.ValidateAsync(this, authorizations).ConfigureAwait(true);
+            Log.Unindent();
             if (!authorizationResult) throw new Exception($"Authorization failed with status {authorizationResult}");
 
             // Get certificate
-            Trace.WriteLine("Processing certificate:");
-            Trace.Indent();
-            Trace.Write("Requesting certificate...");
-            var certChain = await orderContext.Generate(new CsrInfo() { }, certKey).ConfigureAwait(false);
-            Trace.WriteLine("OK");
+            Log.WriteLine("Processing certificate:");
+            Log.Indent();
+            Log.Write("Requesting certificate...");
+            var certChain = await orderContext.Generate(new CsrInfo() {
+                    CommonName = hostNames.First()
+            }, certKey).ConfigureAwait(true);
+            Log.WriteLine("OK");
 
             // Export PFX
-            Trace.Write("Exporting PFX...");
+            Log.Write("Exporting PFX...");
             var pfxBuilder = certChain.ToPfx(certKey);
             pfxBuilder.FullChain = false;
             var pfxData = pfxBuilder.Build(hostNames.First(), pfxPassword);
-            Trace.WriteLine("OK");
-            Trace.Unindent();
+            Log.WriteLine("OK");
+            Log.Unindent();
             return new CertificateRequestResult {
                     Certificate = new X509Certificate2(certChain.Certificate.ToDer()),
                     PrivateKey = new KeyInfo() {PrivateKeyInfo = certKey.ToDer()},
@@ -111,19 +112,19 @@ namespace Altairis.AutoAcme.Core {
             if (string.IsNullOrWhiteSpace(serializedAccountData)) throw new ArgumentException("Value cannot be empty or whitespace only string.", nameof(serializedAccountData));
             var legacyAccount = JsonConvert.DeserializeObject<AcmeAccount>(serializedAccountData);
             context = new AcmeContext(serverAddress, KeyFactory.FromDer(legacyAccount.Key.PrivateKeyInfo), client);
-            Trace.Write($"Accepting TOS at {legacyAccount.Data.Agreement}...");
+            Log.Write($"Accepting TOS at {legacyAccount.Data.Agreement}...");
             try {
-                var accountContext = await context.Account().ConfigureAwait(false);
-                await accountContext.Update(agreeTermsOfService: true).ConfigureAwait(false);
+                var accountContext = await context.Account().ConfigureAwait(true);
+                await accountContext.Update(agreeTermsOfService: true).ConfigureAwait(true);
             }
             catch (AcmeRequestException ex) {
                 if (ex.Error?.Type != "urn:ietf:params:acme:error:accountDoesNotExist") {
                     throw;
                 }
-                Trace.WriteLine("Migrating account...");
+                Log.WriteLine("Migrating account...");
                 await context.NewAccount(legacyAccount.Data.Contact, true).ConfigureAwait(true);
             }
-            Trace.WriteLine("OK");
+            Log.WriteLine("OK");
         }
 
         public string RegisterAndLogin(string email) { return RegisterAndLoginAsync(email).Result; }
@@ -133,16 +134,16 @@ namespace Altairis.AutoAcme.Core {
             if (string.IsNullOrWhiteSpace(email)) throw new ArgumentException("Value cannot be empty or whitespace only string.", nameof(email));
             if (client == null) throw new ObjectDisposedException(nameof(AutoAcmeContext));
             context = new AcmeContext(serverAddress, null, client);
-            Trace.Write($"Creating registration for '{email}' and accept TOS...");
+            Log.Write($"Creating registration for '{email}' and accept TOS...");
             var contacts = new[] {"mailto:"+email};
-            var accountContext = await context.NewAccount(contacts, true).ConfigureAwait(false);
-            Trace.WriteLine("OK");
+            var accountContext = await context.NewAccount(contacts, true).ConfigureAwait(true);
+            Log.WriteLine("OK");
             // For compatibility with earlier versions, use the V1 account object for storage
             AcmeAccount legacyAccount = new AcmeAccount() {
                     ContentType = "application/json",
                     Key = new KeyInfo() {PrivateKeyInfo = context.AccountKey.ToDer()},
                     Data = {
-                            Agreement = await context.TermsOfService().ConfigureAwait(false),
+                            Agreement = await context.TermsOfService().ConfigureAwait(true),
                             Contact = contacts,
                             Resource = "reg"
                     },

--- a/Altairis.AutoAcme.Core/CertificateRequestResult.cs
+++ b/Altairis.AutoAcme.Core/CertificateRequestResult.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using Certes.Pkcs;
@@ -19,9 +18,9 @@ namespace Altairis.AutoAcme.Core {
             // Save to PFX file
             if (!string.IsNullOrWhiteSpace(pfxFolder)) {
                 var pfxFileName = Path.Combine(pfxFolder, hostName + ".pfx");
-                Trace.Write($"Saving PFX to {pfxFileName}...");
+                Log.Write($"Saving PFX to {pfxFileName}...");
                 File.WriteAllBytes(pfxFileName, this.PfxData);
-                Trace.WriteLine("OK");
+                Log.WriteLine("OK");
             }
 
             // Save to PEM file
@@ -29,19 +28,19 @@ namespace Altairis.AutoAcme.Core {
                 var pemFileName = Path.Combine(pemFolder, hostName + ".pem");
                 var crtFileName = Path.Combine(pemFolder, hostName + ".crt");
 
-                Trace.Write($"Saving PEM to {pemFileName}...");
+                Log.Write($"Saving PEM to {pemFileName}...");
                 using (var f = File.Create(pemFileName)) {
                     this.PrivateKey.Save(f);
                 }
-                Trace.WriteLine("OK");
+                Log.WriteLine("OK");
 
-                Trace.Write($"Saving CRT to {crtFileName}...");
+                Log.Write($"Saving CRT to {crtFileName}...");
                 using (var f = File.CreateText(crtFileName)) {
                     f.WriteLine("-----BEGIN CERTIFICATE-----");
                     f.WriteLine(Convert.ToBase64String(this.Certificate.GetRawCertData(), Base64FormattingOptions.InsertLineBreaks));
                     f.WriteLine("-----END CERTIFICATE-----");
                 }
-                Trace.WriteLine("OK");
+                Log.WriteLine("OK");
             }
         }
 

--- a/Altairis.AutoAcme.Core/Challenges/ChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/ChallengeResponseProvider.cs
@@ -9,7 +9,7 @@ using Certes.Acme;
 using Certes.Acme.Resource;
 
 namespace Altairis.AutoAcme.Core.Challenges {
-    public abstract class ChallengeResponseProvider: IDisposable {
+    public abstract class ChallengeResponseProvider: IChallengeResponseProvider {
         protected ChallengeResponseProvider(bool verboseMode) {
             VerboseMode = verboseMode;
         }

--- a/Altairis.AutoAcme.Core/Challenges/ChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/ChallengeResponseProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -10,12 +9,6 @@ using Certes.Acme.Resource;
 
 namespace Altairis.AutoAcme.Core.Challenges {
     public abstract class ChallengeResponseProvider: IChallengeResponseProvider {
-        protected ChallengeResponseProvider(bool verboseMode) {
-            VerboseMode = verboseMode;
-        }
-
-        public bool VerboseMode { get; }
-
         public abstract string ChallengeType { get; }
 
         public void Dispose() {
@@ -29,28 +22,33 @@ namespace Altairis.AutoAcme.Core.Challenges {
 
         public async Task<bool> ValidateAsync(AutoAcmeContext context, IEnumerable<IAuthorizationContext> authorizationContexts) {
             // Get challenge
-            Trace.Write("Getting challenge...");
-            var records = new List<IDisposable>();
+            Log.WriteLine("Getting challenge...");
+            var handlers = new List<IDisposable>();
             var result = true;
             try {
                 // Prepare challenges
                 var challenges = new Dictionary<Uri, IChallengeContext>();
+                Log.Indent();
                 foreach (var authorizationContext in authorizationContexts) {
-                    var authorization = await authorizationContext.Resource().ConfigureAwait(false);
-                    Trace.WriteLine("OK, the following is DNS name:");
-                    Trace.WriteLine(authorization.Identifier.Value);
-                    var ch = await authorizationContext.Challenge(ChallengeType).ConfigureAwait(false);
-                    var challenge = await CreateChallengeHandler(ch, authorization.Identifier.Value, context.AccountKey).ConfigureAwait(false);
-                    records.Add(challenge);
+                    var authorization = await authorizationContext.Resource().ConfigureAwait(true);
+                    Log.WriteLine("OK, the following is DNS name:");
+                    Log.Indent();
+                    Log.WriteLine(authorization.Identifier.Value);
+                    var ch = await authorizationContext.Challenge(ChallengeType).ConfigureAwait(true);
+                    var handler = await CreateChallengeHandler(ch, authorization.Identifier.Value, context.AccountKey).ConfigureAwait(true);
+                    Log.Unindent();
+                    handlers.Add(handler);
                     challenges.Add(ch.Location, ch);
                 }
-                Trace.Write("Completing challenge");
+                Log.Unindent();
+                Log.Write("Completing challenge");
+                var challengeTasks = challenges.Values.Select(ch => ch.Validate());
                 for (var i = 0; i < context.ChallengeVerificationRetryCount; i++) {
-                    Trace.Write(".");
-                    foreach (var challenge in await Task.WhenAll(challenges.Values.Select(ch => ch.Validate())).ConfigureAwait(false)) {
+                    Log.Write(".");
+                    foreach (var challenge in await Task.WhenAll(challengeTasks).ConfigureAwait(true)) {
                         switch (challenge.Status) {
                             case ChallengeStatus.Invalid:
-                                Trace.WriteLine($"Challenge {challenge.Status}: {challenge.Url} {challenge.Error?.Detail}");
+                                Log.WriteLine($"Challenge {challenge.Status}: {challenge.Url} {challenge.Error?.Detail}");
                                 challenges.Remove(challenge.Url);
                                 result = false;
                                 break;
@@ -62,20 +60,26 @@ namespace Altairis.AutoAcme.Core.Challenges {
                     if (challenges.Count == 0) {
                         break;
                     }
-                    await Task.Delay(context.ChallengeVerificationWait).ConfigureAwait(false);
+                    await Task.Delay(context.ChallengeVerificationWait).ConfigureAwait(true);
+                    challengeTasks = challenges.Values.Select(ch => ch.Resource());
                 }
                 // Complete challenge
-                Trace.WriteLine(result ? "OK" : "Failed");
+                Log.WriteLine(result ? "OK" : "Failed");
                 return result;
             }
             catch (Exception ex) {
-                Trace.WriteLine("Challenge exception:");
-                Trace.WriteLine(ex.ToString());
+                Log.WriteLine("Challenge exception:");
+                Log.WriteLine(ex.ToString());
                 return false;
             }
             finally {
-                foreach (var record in records) {
-                    record.Dispose();
+                foreach (var handler in handlers) {
+                    try {
+                        handler.Dispose();
+                    }
+                    catch (Exception ex) {
+                        Log.WriteLine("Error on challenge response disposal (maybe requires manual cleanup): "+ex.Message);
+                    }
                 }
             }
         }

--- a/Altairis.AutoAcme.Core/Challenges/DnsChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/DnsChallengeResponseProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Management;
 using System.Threading.Tasks;
@@ -15,21 +14,29 @@ namespace Altairis.AutoAcme.Core.Challenges {
     public class DnsChallengeResponseProvider: ChallengeResponseProvider {
         private class TxtRecord: IDisposable {
             private readonly DnsChallengeResponseProvider owner;
-            private readonly string rr;
+            private readonly string path;
 
             public TxtRecord(DnsChallengeResponseProvider owner, string fullName, string value) {
                 this.owner = owner;
                 FullName = fullName;
-                var scopedClass = new ManagementClass(owner.scope, TXT_RECORD, null);
-                var newObj = InvokeMethodAsync(scopedClass, "CreateInstanceFromPropertyData", owner.dnsServer, owner.dnsDomain, FullName, 1, 10, value).Result;
-                rr = (string)newObj["RR"];
+                using (var scopedClass = new ManagementClass(owner.scope, TXT_RECORD, null)) {
+                    using (var newObj = InvokeMethodAsync(scopedClass, "CreateInstanceFromPropertyData", owner.dnsServer, owner.dnsDomain, FullName, 1, 10, value).Result) {
+                        path = (string)newObj["RR"];
+                        Log.WriteVerboseLine("DNS record: "+path);
+                    }
+                }
             }
 
             public string FullName { get; }
 
             public void Dispose() {
-                var record = new ManagementObject(owner.scope, new ManagementPath(rr), null);
-                record.Delete();
+                var record = new ManagementObject(owner.scope, new ManagementPath(path), null);
+                try {
+                    record.Delete();
+                }
+                finally {
+                    record.Dispose();
+                }
             }
         }
 
@@ -48,65 +55,56 @@ namespace Altairis.AutoAcme.Core.Challenges {
         private readonly ManagementScope scope;
         private readonly LookupClient lookupClient;
 
-        public DnsChallengeResponseProvider(bool verboseMode, string dnsServer, string dnsDomain): base(verboseMode) {
+        public DnsChallengeResponseProvider(string dnsServer, string dnsDomain): base() {
             this.dnsServer = dnsServer;
             this.dnsDomain = dnsDomain.ToAsciiHostName();
             scope = new ManagementScope($@"\\{this.dnsServer}\ROOT\MicrosoftDNS");
+            scope.Connect();
             lookupClient = new LookupClient();
         }
 
         public override string ChallengeType => ChallengeTypes.Dns01;
 
         protected override async Task<IDisposable> CreateChallengeHandler(IChallengeContext ch, string hostName, IKey accountKey) {
-            var cnameQuery = await lookupClient.QueryAsync($"_acme-challenge.{hostName}", QueryType.CNAME).ConfigureAwait(false);
+            var cnameQuery = await lookupClient.QueryAsync($"_acme-challenge.{hostName}", QueryType.CNAME).ConfigureAwait(true);
             var cnameRecord = cnameQuery.Answers.CnameRecords().Single();
             var fullName = cnameRecord.CanonicalName.Value.TrimEnd('.');
-            if (VerboseMode) {
-                Trace.Indent();
-                Trace.WriteLine("DNS CNAME target:");
-                Trace.WriteLine(fullName);
-                Trace.Unindent();
-            }
+            Log.WriteVerboseLine("DNS CNAME target:");
+            Log.WriteVerboseLine(fullName);
             var txt = accountKey.DnsTxt(ch.Token);
-            if (VerboseMode) {
-                Trace.Indent();
-                Trace.WriteLine("DNS value:");
-                Trace.WriteLine(txt);
-                Trace.Unindent();
-            }
+            Log.WriteVerboseLine("DNS value:");
+            Log.WriteVerboseLine(txt);
             return new TxtRecord(this, fullName, txt);
         }
 
         public override async Task<bool> TestAsync(IEnumerable<string> hostNames) {
             try {
-                foreach (var hostName in hostNames.Select(n => n.StartsWith("*.") ? n.Substring(2) : n)) {
+                foreach (var hostName in hostNames.Select(n => n.StartsWith("*.") ? n.Substring(2) : n).Distinct(StringComparer.OrdinalIgnoreCase)) {
                     var acmeChallengeName = $"_acme-challenge.{hostName}";
                     // Test NS configuration of domain
-                    var cnameQuery = await lookupClient.QueryAsync(acmeChallengeName, QueryType.CNAME).ConfigureAwait(false);
+                    var cnameQuery = await lookupClient.QueryAsync(acmeChallengeName, QueryType.CNAME).ConfigureAwait(true);
                     var cnameRecord = cnameQuery.Answers.CnameRecords().SingleOrDefault();
                     if (cnameRecord == null) {
-                        Trace.WriteLine($"No DNS CNAME record found for {acmeChallengeName}");
+                        Log.WriteLine($"No DNS CNAME record found for {acmeChallengeName}");
                         return false;
                     }
                     var fullName = cnameRecord.CanonicalName.Value.TrimEnd('.');
                     if (!fullName.EndsWith("."+dnsDomain, StringComparison.OrdinalIgnoreCase)) {
-                        Trace.WriteLine($"The DNS CNAME record for {acmeChallengeName} points to {fullName} which is not part of {dnsDomain}");
+                        Log.WriteLine($"The DNS CNAME record for {acmeChallengeName} points to {fullName} which is not part of {dnsDomain}");
                         return false;
                     }
-                    if (VerboseMode) {
-                        Trace.WriteLine($"The DNS CNAME record for {acmeChallengeName} points to {fullName}");
-                    }
+                    Log.WriteVerboseLine($"The DNS CNAME record for {acmeChallengeName} points to {fullName}");
                     // Test DNS roundtrip with GUID to prevent caching issues
                     var id = Guid.NewGuid().ToString("n");
                     using (var record = new TxtRecord(this, $"_{id}.{dnsDomain}", id)) {
-                        var query = await lookupClient.QueryAsync(record.FullName, QueryType.TXT).ConfigureAwait(false);
+                        var query = await lookupClient.QueryAsync(record.FullName, QueryType.TXT).ConfigureAwait(true);
                         var txtRecord = query.Answers.TxtRecords().SingleOrDefault();
                         if (txtRecord == null) {
-                            Trace.WriteLine($"The DNS TXT test record was added to {dnsDomain} on {dnsServer}, but could not be retrieved via DNS");
+                            Log.WriteLine($"The DNS TXT test record was added to {dnsDomain} on {dnsServer}, but could not be retrieved via DNS");
                             return false;
                         }
                         if (!txtRecord.Text.Contains(id)) {
-                            Trace.WriteLine($"The DNS TXT test record does not have the expected content");
+                            Log.WriteLine($"The DNS TXT test record does not have the expected content");
                             return false;
                         }
                     }
@@ -114,7 +112,7 @@ namespace Altairis.AutoAcme.Core.Challenges {
                 return true;
             }
             catch (ManagementException ex) {
-                Trace.WriteLine($"Error 0x{(int)ex.ErrorCode:x} occurred while communicating to the DNS server: {ex.Message}");
+                Log.WriteLine($"Error 0x{(int)ex.ErrorCode:x} occurred while communicating to the DNS server: {ex.Message}");
                 return false;
             }
         }

--- a/Altairis.AutoAcme.Core/Challenges/FallbackChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/FallbackChallengeResponseProvider.cs
@@ -19,17 +19,29 @@ namespace Altairis.AutoAcme.Core.Challenges {
                 return Task.FromResult(false);
             }
             var provider = providers[index];
-            Trace.Write("Validate via "+provider.ChallengeType+"...");
-            return provider.ValidateAsync(context, authorizationContexts);
+            Log.WriteLine("Validate via "+provider.ChallengeType+"...");
+            Log.Indent();
+            try {
+                return provider.ValidateAsync(context, authorizationContexts);
+            }
+            finally {
+                Log.Unindent();
+            }
         }
 
         public async Task<bool> TestAsync(IEnumerable<string> hostNames) {
             index = 0;
             while (index < providers.Length) {
                 var provider = providers[index];
-                Trace.Write("Testing "+provider.ChallengeType+"...");
-                if (await provider.TestAsync(hostNames).ConfigureAwait(false)) {
-                    return true;
+                Log.WriteLine($"Testing {provider.ChallengeType}...");
+                Log.Indent();
+                try {
+                    if (await provider.TestAsync(hostNames).ConfigureAwait(true)) {
+                        return true;
+                    }
+                }
+                finally {
+                    Log.Unindent();
                 }
                 index++;
             }

--- a/Altairis.AutoAcme.Core/Challenges/FallbackChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/FallbackChallengeResponseProvider.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+using Certes.Acme;
+
+namespace Altairis.AutoAcme.Core.Challenges {
+    public class FallbackChallengeResponseProvider: IChallengeResponseProvider {
+        private readonly ChallengeResponseProvider[] providers;
+        private int index;
+
+        public FallbackChallengeResponseProvider(params ChallengeResponseProvider[] providers) { this.providers = providers; }
+
+        public void Dispose() { Array.ForEach(providers, provider => provider.Dispose()); }
+
+        public Task<bool> ValidateAsync(AutoAcmeContext context, IEnumerable<IAuthorizationContext> authorizationContexts) {
+            if (index >= providers.Length) {
+                return Task.FromResult(false);
+            }
+            var provider = providers[index];
+            Trace.Write("Validate via "+provider.ChallengeType+"...");
+            return provider.ValidateAsync(context, authorizationContexts);
+        }
+
+        public async Task<bool> TestAsync(IEnumerable<string> hostNames) {
+            index = 0;
+            while (index < providers.Length) {
+                var provider = providers[index];
+                Trace.Write("Testing "+provider.ChallengeType+"...");
+                if (await provider.TestAsync(hostNames).ConfigureAwait(false)) {
+                    return true;
+                }
+                index++;
+            }
+            return false;
+        }
+    }
+}

--- a/Altairis.AutoAcme.Core/Challenges/HttpChallengeFileResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/HttpChallengeFileResponseProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 
 namespace Altairis.AutoAcme.Core.Challenges {
@@ -9,22 +8,22 @@ namespace Altairis.AutoAcme.Core.Challenges {
 
             public ChallengeFile(string fileName, string authString) {
                 this.fileName = fileName;
-                Trace.Write($"Writing challenge to {fileName}...");
+                Log.Write($"Writing challenge to {fileName}...");
                 File.WriteAllText(fileName, authString);
-                Trace.WriteLine("OK");
+                Log.WriteLine("OK");
             }
 
             public void Dispose() {
                 if (!File.Exists(fileName)) return;
-                Trace.Write($"Deleting challenge from {fileName}...");
+                Log.Write($"Deleting challenge from {fileName}...");
                 File.Delete(fileName);
-                Trace.WriteLine("OK");
+                Log.WriteLine("OK");
             }
         }
 
         private readonly string challengeFolder;
 
-        public HttpChallengeFileResponseProvider(bool verboseMode, string challengeFolder): base(verboseMode) { this.challengeFolder = challengeFolder; }
+        public HttpChallengeFileResponseProvider(string challengeFolder): base() { this.challengeFolder = challengeFolder; }
 
         protected override IDisposable CreateChallengeHandler(string tokenId, string authString) { return new ChallengeFile(Path.Combine(challengeFolder, tokenId), authString); }
     }

--- a/Altairis.AutoAcme.Core/Challenges/HttpChallengeHostedResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/HttpChallengeHostedResponseProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -21,14 +20,13 @@ namespace Altairis.AutoAcme.Core.Challenges {
         }
 
         private readonly Dictionary<string, string> authStrings = new Dictionary<string, string>(StringComparer.Ordinal);
-
         private readonly HttpListener listener;
 
-        public HttpChallengeHostedResponseProvider(bool verboseMode, string urlPrefix): base(verboseMode) {
+        public HttpChallengeHostedResponseProvider(string urlPrefix): base() {
             listener = new HttpListener();
             listener.Prefixes.Add(urlPrefix);
             listener.Start();
-            Trace.WriteLine("Listening on "+urlPrefix);
+            Log.WriteLine("Listening on "+urlPrefix);
             listener.GetContextAsync().ContinueWith(HandleRequest, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
@@ -49,7 +47,8 @@ namespace Altairis.AutoAcme.Core.Challenges {
             listener.GetContextAsync().ContinueWith(HandleRequest, TaskContinuationOptions.OnlyOnRanToCompletion);
             var request = task.Result.Request;
             var response = task.Result.Response;
-            Trace.WriteLine("Handling request from "+request.RemoteEndPoint.Address);
+            Log.AssertNewLine();
+            Log.WriteLine($"(Handling request from {request.RemoteEndPoint.Address})");
             var tokenId = request.Url.AbsolutePath.Substring(request.Url.AbsolutePath.LastIndexOf('/')+1);
             string authString;
             if (!authStrings.TryGetValue(tokenId, out authString)) {

--- a/Altairis.AutoAcme.Core/Challenges/IChallengeResponseProvider.cs
+++ b/Altairis.AutoAcme.Core/Challenges/IChallengeResponseProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Certes.Acme;
+
+namespace Altairis.AutoAcme.Core.Challenges {
+    public interface IChallengeResponseProvider: IDisposable {
+        Task<bool> ValidateAsync(AutoAcmeContext context, IEnumerable<IAuthorizationContext> authorizationContexts);
+
+        Task<bool> TestAsync(IEnumerable<string> hostNames);
+    }
+}

--- a/Altairis.AutoAcme.Core/Log.cs
+++ b/Altairis.AutoAcme.Core/Log.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Altairis.AutoAcme.Core {
+    public static class Log {
+        private static int indent = 0;
+        private static bool isNewLine = true;
+
+        public static bool VerboseMode;
+
+        public static void Indent() { indent++; }
+
+        public static void Unindent() {
+            if (indent > 0)
+                indent--;
+        }
+
+        public static void Exception(Exception ex, string message) {
+            AssertNewLine();
+            Write(message);
+            if (ex is AggregateException aex) {
+                WriteLine("!");
+                foreach (var iaex in aex.Flatten().InnerExceptions) {
+                    WriteLine(iaex.Message);
+                    WriteVerboseLine();
+                    WriteVerboseLine(iaex.ToString());
+                }
+            } else {
+                Write(": ");
+                WriteLine(ex.Message);
+                WriteVerboseLine();
+                WriteVerboseLine(ex.ToString());
+            }
+        }
+
+        public static void AssertNewLine() {
+            if (!isNewLine) {
+                WriteLine();
+            }
+        }
+
+        public static void Write(string value) {
+            if (!String.IsNullOrEmpty(value)) {
+                if (isNewLine) {
+                    if (indent > 0) {
+                        Trace.Write(new string(' ', indent * 2));
+                    }
+                    isNewLine = false;
+                }
+                Trace.Write(value);
+            }
+        }
+
+        public static void WriteLine(string value = null) {
+            if (value != null) {
+                Write(value);
+            }
+            Trace.WriteLine(String.Empty);
+            isNewLine = true;
+        }
+
+        public static void WriteVerboseLine(string value = null) {
+            if (VerboseMode) {
+                AssertNewLine();
+                WriteLine(value);
+            }
+        }
+    }
+}

--- a/Altairis.AutoAcme.Core/app.config
+++ b/Altairis.AutoAcme.Core/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.1.1.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />

--- a/Altairis.AutoAcme.IisSync/Altairis.AutoAcme.IisSync.csproj
+++ b/Altairis.AutoAcme.IisSync/Altairis.AutoAcme.IisSync.csproj
@@ -53,7 +53,7 @@
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
@@ -61,8 +61,8 @@
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/Altairis.AutoAcme.IisSync/App.config
+++ b/Altairis.AutoAcme.IisSync/App.config
@@ -15,7 +15,7 @@
       <probing privatePath="lib" />
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.1.1.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/Altairis.AutoAcme.IisSync/packages.config
+++ b/Altairis.AutoAcme.IisSync/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="NConsoler" version="2.0.0.0" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net461" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net461" />
 </packages>

--- a/Altairis.AutoAcme.Manager/Altairis.AutoAcme.Manager.csproj
+++ b/Altairis.AutoAcme.Manager/Altairis.AutoAcme.Manager.csproj
@@ -65,11 +65,9 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>

--- a/Altairis.AutoAcme.Manager/App.config
+++ b/Altairis.AutoAcme.Manager/App.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.1.1.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="BouncyCastle.Crypto" publicKeyToken="0e99375e54769942" culture="neutral" />


### PR DESCRIPTION
This allows to use both DNS and self-hosted HTTP challenges safely at the same time. When the DNS setup (CNAME or otherwise) does not match the expectation, HTTP is used. Documented in https://github.com/ridercz/AutoACME/wiki/AutoACME-in-a-web-farm-environment