### PR TITLE
Object not set to an instance of an object

### DIFF
--- a/Altairis.AutoAcme.Core/AutoAcmeContext.cs
+++ b/Altairis.AutoAcme.Core/AutoAcmeContext.cs
@@ -143,12 +143,13 @@ namespace Altairis.AutoAcme.Core {
                     ContentType = "application/json",
                     Key = new KeyInfo() {PrivateKeyInfo = context.AccountKey.ToDer()},
                     Data = {
-                            Agreement = await context.TermsOfService().ConfigureAwait(true),
                             Contact = contacts,
                             Resource = "reg"
                     },
                     Location = accountContext.Location
             };
+
+            legacyAccount.Data.Agreement = await context.TermsOfService().ConfigureAwait(true);
             return JsonConvert.SerializeObject(legacyAccount);
         }
     }


### PR DESCRIPTION
I was receiving "object not set to an instance of an object" exception when trying to create certificate for multiple subdomains. 
Updated packages and expanded the creation of AcmeAccount. I no longer receive the exception.