### PR TITLE
Implements #24 - add chain certificates to CRT file

### DIFF
--- a/Altairis.AutoAcme.Core/CertificateRequestResult.cs
+++ b/Altairis.AutoAcme.Core/CertificateRequestResult.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
+
 using Certes.Pkcs;
 
 namespace Altairis.AutoAcme.Core {
     public class CertificateRequestResult {
+        private static void WriteCertificateData(TextWriter writer, X509Certificate2 certificate) {
+            writer.WriteLine("-----BEGIN CERTIFICATE-----");
+            writer.WriteLine(Convert.ToBase64String(certificate.GetRawCertData(), Base64FormattingOptions.InsertLineBreaks));
+            writer.WriteLine("-----END CERTIFICATE-----");
+        }
 
         public X509Certificate2 Certificate { get; set; }
 
@@ -18,32 +24,39 @@ namespace Altairis.AutoAcme.Core {
             // Save to PFX file
             if (!string.IsNullOrWhiteSpace(pfxFolder)) {
                 // IIS. For IDN names, the Centralized Certificate Store expects the literal unicode name, not the punycode name
-                var pfxFileName = Path.Combine(pfxFolder, hostName.ToUnicodeHostName() + ".pfx");
+                var pfxFileName = Path.Combine(pfxFolder, hostName.ToUnicodeHostName()+".pfx");
                 Log.Write($"Saving PFX to {pfxFileName}...");
-                File.WriteAllBytes(pfxFileName, this.PfxData);
+                File.WriteAllBytes(pfxFileName, PfxData);
                 Log.WriteLine("OK");
             }
 
             // Save to PEM file
             if (!string.IsNullOrWhiteSpace(pemFolder)) {
-                var pemFileName = Path.Combine(pemFolder, hostName + ".pem");
-                var crtFileName = Path.Combine(pemFolder, hostName + ".crt");
-
+                var pemFileName = Path.Combine(pemFolder, hostName+".pem");
+                var crtFileName = Path.Combine(pemFolder, hostName+".crt");
                 Log.Write($"Saving PEM to {pemFileName}...");
                 using (var f = File.Create(pemFileName)) {
-                    this.PrivateKey.Save(f);
+                    PrivateKey.Save(f);
                 }
                 Log.WriteLine("OK");
-
                 Log.Write($"Saving CRT to {crtFileName}...");
                 using (var f = File.CreateText(crtFileName)) {
-                    f.WriteLine("-----BEGIN CERTIFICATE-----");
-                    f.WriteLine(Convert.ToBase64String(this.Certificate.GetRawCertData(), Base64FormattingOptions.InsertLineBreaks));
-                    f.WriteLine("-----END CERTIFICATE-----");
+                    WriteCertificateData(f, Certificate);
+                    var chain = new X509Chain() {
+                            ChainPolicy = new X509ChainPolicy() {
+                                    RevocationMode = X509RevocationMode.NoCheck
+                            }
+                    };
+                    if (chain.Build(Certificate)) {
+                        for (var i = 1; i < chain.ChainElements.Count-1; i++) {
+                            WriteCertificateData(f, chain.ChainElements[i].Certificate);
+                        }
+                    } else {
+                        Log.WriteLine($"Warning: The chain of the certificate could not be exported to {crtFileName}");
+                    }
                 }
                 Log.WriteLine("OK");
             }
         }
-
     }
 }


### PR DESCRIPTION
This implements the request in #24 by concating the intermediate certificates of the chain to the CRT file.